### PR TITLE
Simplified authorization

### DIFF
--- a/JwtWebApiTutorial/Program.cs
+++ b/JwtWebApiTutorial/Program.cs
@@ -18,10 +18,11 @@ builder.Services.AddSwaggerGen(options =>
 {
     options.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
     {
-        Description = "Standard Authorization header using the Bearer scheme (\"bearer {token}\")",
+        Description = "Standard Authorization header using the Bearer scheme",
         In = ParameterLocation.Header,
         Name = "Authorization",
-        Type = SecuritySchemeType.ApiKey
+        Type = SecuritySchemeType.Http,
+        Scheme = "Bearer"
     });
 
     options.OperationFilter<SecurityRequirementsOperationFilter>();


### PR DESCRIPTION
Hi Patrick God
I am try to simplified authorization step. 
If follow this modified, there is no need to enter `bearer` when authorize the token.
![image](https://user-images.githubusercontent.com/18715360/182589164-b2db82b9-57ac-42bf-a5da-e19cbf17a874.png)


